### PR TITLE
feat: Implement custom phone number input field

### DIFF
--- a/lib/domain/bloc/user/user_bloc.dart
+++ b/lib/domain/bloc/user/user_bloc.dart
@@ -8,8 +8,11 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 part 'user_event.dart';
 part 'user_state.dart';
 
+import 'package:firebase_auth/firebase_auth.dart';
+
 class UserBloc extends Bloc<UserEvent, UserState> {
   final UserServices _userServices = UserServices();
+  final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
 
   UserBloc() : super(const UserState()) {
     on<OnGetUserEvent>(_onGetUser);
@@ -61,6 +64,12 @@ class UserBloc extends Bloc<UserEvent, UserState> {
         name: event.name,
         lastname: event.lastname,
         phone: event.phone,
+        country: event.country,
+        countryCode: event.countryCode,
+        dialingCode: event.dialingCode,
+        flag: event.flag,
+        currency: event.currency,
+        geo: event.geo,
       );
       await _userServices.updateUser(updatedUser);
       final user = await _userServices.getUserById(state.user!.uid);
@@ -86,7 +95,25 @@ class UserBloc extends Bloc<UserEvent, UserState> {
       OnRegisterClientEvent event, Emitter<UserState> emit) async {
     try {
       emit(LoadingUserState());
-      // TODO: Implement client registration with Firebase Auth and Firestore
+      final userCredential = await _firebaseAuth.createUserWithEmailAndPassword(
+        email: event.email,
+        password: event.password,
+      );
+      final user = UserModel.User(
+        uid: userCredential.user!.uid,
+        name: event.name,
+        lastname: event.lastname,
+        email: event.email,
+        phone: event.phone,
+        rolId: '2', // Assuming '2' is for clients
+        country: event.country,
+        countryCode: event.countryCode,
+        dialingCode: event.dialingCode,
+        flag: event.flag,
+        currency: event.currency,
+        geo: event.geo,
+      );
+      await _userServices.addUser(user);
       emit(SuccessUserState());
     } catch (e) {
       emit(FailureUserState(e.toString()));
@@ -97,7 +124,25 @@ class UserBloc extends Bloc<UserEvent, UserState> {
       OnRegisterDeliveryEvent event, Emitter<UserState> emit) async {
     try {
       emit(LoadingUserState());
-      // TODO: Implement delivery registration with Firebase Auth and Firestore
+      final userCredential = await _firebaseAuth.createUserWithEmailAndPassword(
+        email: event.email,
+        password: event.password,
+      );
+      final user = UserModel.User(
+        uid: userCredential.user!.uid,
+        name: event.name,
+        lastname: event.lastname,
+        email: event.email,
+        phone: event.phone,
+        rolId: '3', // Assuming '3' is for delivery
+        country: event.country,
+        countryCode: event.countryCode,
+        dialingCode: event.dialingCode,
+        flag: event.flag,
+        currency: event.currency,
+        geo: event.geo,
+      );
+      await _userServices.addUser(user);
       emit(SuccessUserState());
     } catch (e) {
       emit(FailureUserState(e.toString()));

--- a/lib/domain/bloc/user/user_event.dart
+++ b/lib/domain/bloc/user/user_event.dart
@@ -34,8 +34,14 @@ class OnEditUserEvent extends UserEvent {
   final String name;
   final String lastname;
   final String phone;
+  final String country;
+  final String countryCode;
+  final String dialingCode;
+  final String flag;
+  final Map<String, dynamic> currency;
+  final Map<String, dynamic> geo;
 
-  OnEditUserEvent(this.name, this.lastname, this.phone);
+  OnEditUserEvent(this.name, this.lastname, this.phone, this.country, this.countryCode, this.dialingCode, this.flag, this.currency, this.geo);
 }
 
 
@@ -53,11 +59,28 @@ class OnRegisterDeliveryEvent extends UserEvent {
   final String phone;
   final String email;
   final String password;
-  final String image; 
+  final String image;
+  final String country;
+  final String countryCode;
+  final String dialingCode;
+  final String flag;
+  final Map<String, dynamic> currency;
+  final Map<String, dynamic> geo;
 
-  OnRegisterDeliveryEvent(this.name, this.lastname, this.phone, this.email, this.password, this.image);
+  OnRegisterDeliveryEvent(
+      this.name,
+      this.lastname,
+      this.phone,
+      this.email,
+      this.password,
+      this.image,
+      this.country,
+      this.countryCode,
+      this.dialingCode,
+      this.flag,
+      this.currency,
+      this.geo);
 }
-
 
 class OnRegisterClientEvent extends UserEvent {
   final String name;
@@ -66,9 +89,26 @@ class OnRegisterClientEvent extends UserEvent {
   final String email;
   final String password;
   final String image;
+  final String country;
+  final String countryCode;
+  final String dialingCode;
+  final String flag;
+  final Map<String, dynamic> currency;
+  final Map<String, dynamic> geo;
 
-  OnRegisterClientEvent(this.name, this.lastname, this.phone, this.email, this.password, this.image);
-
+  OnRegisterClientEvent(
+      this.name,
+      this.lastname,
+      this.phone,
+      this.email,
+      this.password,
+      this.image,
+      this.country,
+      this.countryCode,
+      this.dialingCode,
+      this.flag,
+      this.currency,
+      this.geo);
 }
 
 

--- a/lib/domain/models/country_model.dart
+++ b/lib/domain/models/country_model.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+Country countryFromJson(String str) => Country.fromJson(json.decode(str));
+
+String countryToJson(Country data) => json.encode(data.toJson());
+
+class Country {
+  final String label;
+  final String code;
+  final Currency currency;
+  final String dialingCode;
+  final String flag;
+  final List<County> counties;
+
+  Country({
+    required this.label,
+    required this.code,
+    required this.currency,
+    required this.dialingCode,
+    required this.flag,
+    required this.counties,
+  });
+
+  factory Country.fromJson(Map<String, dynamic> json) => Country(
+        label: json["label"],
+        code: json["code"],
+        currency: Currency.fromJson(json["currency"]),
+        dialingCode: json["dialingCode"],
+        flag: json["flag"],
+        counties:
+            List<County>.from(json["counties"].map((x) => County.fromJson(x))),
+      );
+
+  Map<String, dynamic> toJson() => {
+        "label": label,
+        "code": code,
+        "currency": currency.toJson(),
+        "dialingCode": dialingCode,
+        "flag": flag,
+        "counties": List<dynamic>.from(counties.map((x) => x.toJson())),
+      };
+}
+
+class County {
+  final String label;
+  final List<SubCounty> subCounties;
+
+  County({
+    required this.label,
+    required this.subCounties,
+  });
+
+  factory County.fromJson(Map<String, dynamic> json) => County(
+        label: json["label"],
+        subCounties: List<SubCounty>.from(
+            json["subCounties"].map((x) => SubCounty.fromJson(x))),
+      );
+
+  Map<String, dynamic> toJson() => {
+        "label": label,
+        "subCounties": List<dynamic>.from(subCounties.map((x) => x.toJson())),
+      };
+}
+
+class SubCounty {
+  final String label;
+  final List<String> wards;
+
+  SubCounty({
+    required this.label,
+    required this.wards,
+  });
+
+  factory SubCounty.fromJson(Map<String, dynamic> json) => SubCounty(
+        label: json["label"],
+        wards: List<String>.from(json["wards"].map((x) => x)),
+      );
+
+  Map<String, dynamic> toJson() => {
+        "label": label,
+        "wards": List<dynamic>.from(wards.map((x) => x)),
+      };
+}
+
+class Currency {
+  final String name;
+  final String code;
+
+  Currency({
+    required this.name,
+    required this.code,
+  });
+
+  factory Currency.fromJson(Map<String, dynamic> json) => Currency(
+        name: json["name"],
+        code: json["code"],
+      );
+
+  Map<String, dynamic> toJson() => {
+        "name": name,
+        "code": code,
+      };
+}

--- a/lib/domain/models/user.dart
+++ b/lib/domain/models/user.dart
@@ -7,6 +7,12 @@ class User {
   final String? image;
   final String rolId;
   final String? notificationToken;
+  final String? country;
+  final String? countryCode;
+  final String? dialingCode;
+  final String? flag;
+  final Map<String, dynamic>? currency;
+  final Map<String, dynamic>? geo;
 
   User({
     required this.uid,
@@ -17,6 +23,12 @@ class User {
     this.image,
     required this.rolId,
     this.notificationToken,
+    this.country,
+    this.countryCode,
+    this.dialingCode,
+    this.flag,
+    this.currency,
+    this.geo,
   });
 
   Map<String, dynamic> toMap() {
@@ -29,6 +41,12 @@ class User {
       'image': image,
       'rolId': rolId,
       'notificationToken': notificationToken,
+      'country': country,
+      'countryCode': countryCode,
+      'dialingCode': dialingCode,
+      'flag': flag,
+      'currency': currency,
+      'geo': geo,
     };
   }
 
@@ -42,6 +60,46 @@ class User {
       image: map['image'],
       rolId: map['rolId'],
       notificationToken: map['notificationToken'],
+      country: map['country'],
+      countryCode: map['countryCode'],
+      dialingCode: map['dialingCode'],
+      flag: map['flag'],
+      currency: map['currency'],
+      geo: map['geo'],
+    );
+  }
+
+  User copyWith({
+    String? uid,
+    String? name,
+    String? lastname,
+    String? email,
+    String? phone,
+    String? image,
+    String? rolId,
+    String? notificationToken,
+    String? country,
+    String? countryCode,
+    String? dialingCode,
+    String? flag,
+    Map<String, dynamic>? currency,
+    Map<String, dynamic>? geo,
+  }) {
+    return User(
+      uid: uid ?? this.uid,
+      name: name ?? this.name,
+      lastname: lastname ?? this.lastname,
+      email: email ?? this.email,
+      phone: phone ?? this.phone,
+      image: image ?? this.image,
+      rolId: rolId ?? this.rolId,
+      notificationToken: notificationToken ?? this.notificationToken,
+      country: country ?? this.country,
+      countryCode: countryCode ?? this.countryCode,
+      dialingCode: dialingCode ?? this.dialingCode,
+      flag: flag ?? this.flag,
+      currency: currency ?? this.currency,
+      geo: geo ?? this.geo,
     );
   }
 }

--- a/lib/presentation/components/phone_number_field.dart
+++ b/lib/presentation/components/phone_number_field.dart
@@ -1,0 +1,330 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:dukascango/domain/models/country_model.dart';
+import 'package:dukascango/presentation/components/text_custom.dart';
+
+class PhoneNumberField extends StatefulWidget {
+  final Function(String fullPhoneNumber, Map<String, dynamic> countryData)
+      onChanged;
+
+  const PhoneNumberField({Key? key, required this.onChanged}) : super(key: key);
+
+  @override
+  _PhoneNumberFieldState createState() => _PhoneNumberFieldState();
+}
+
+class _PhoneNumberFieldState extends State<PhoneNumberField> {
+  List<Country> _countries = [];
+  Country? _selectedCountry;
+  County? _selectedCounty;
+  SubCounty? _selectedSubCounty;
+  String? _selectedWard;
+  bool _showGeoFields = false;
+
+  final TextEditingController _phoneController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCountries();
+    _phoneController.addListener(_onPhoneChanged);
+  }
+
+  Future<void> _loadCountries() async {
+    final String response =
+        await rootBundle.loadString('assets/json/country_data.json');
+    final List<dynamic> data = json.decode(response);
+    setState(() {
+      _countries = data.map((json) => Country.fromJson(json)).toList();
+      _selectedCountry =
+          _countries.firstWhere((c) => c.code == 'KE', orElse: () => _countries.first);
+    });
+  }
+
+  void _onPhoneChanged() {
+    setState(() {
+      _showGeoFields = _phoneController.text.isNotEmpty &&
+          _selectedCountry != null &&
+          _selectedCountry!.counties.isNotEmpty;
+    });
+
+    if (_selectedCountry != null) {
+      final String fullPhoneNumber =
+          '+${_selectedCountry!.dialingCode}${_phoneController.text}';
+      final Map<String, dynamic> countryData = {
+        "country": _selectedCountry!.label,
+        "countryCode": _selectedCountry!.code,
+        "dialingCode": "+${_selectedCountry!.dialingCode}",
+        "phoneNumber": fullPhoneNumber,
+        "flag": _selectedCountry!.flag,
+        "currency": _selectedCountry!.currency.toJson(),
+        "geo": {
+          "county": _selectedCounty?.label,
+          "subCounty": _selectedSubCounty?.label,
+          "ward": _selectedWard,
+        }
+      };
+      widget.onChanged(fullPhoneNumber, countryData);
+    }
+  }
+
+  @override
+  void dispose() {
+    _phoneController.removeListener(_onPhoneChanged);
+    _phoneController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const TextCustom(text: 'Phone Number'),
+        const SizedBox(height: 5.0),
+        Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(5.0),
+            border: Border.all(width: .5, color: Colors.grey),
+          ),
+          child: Row(
+            children: [
+              _buildCountryPicker(),
+              Expanded(
+                child: TextFormField(
+                  controller: _phoneController,
+                  keyboardType: TextInputType.phone,
+                  style: GoogleFonts.getFont('Roboto', fontSize: 18),
+                  decoration: InputDecoration(
+                    border: InputBorder.none,
+                    contentPadding: const EdgeInsets.only(left: 15.0),
+                    hintText: 'Enter phone number',
+                    hintStyle: GoogleFonts.getFont('Roboto', color: Colors.grey),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (_showGeoFields) ..._buildGeoFields(),
+      ],
+    );
+  }
+
+  Widget _buildCountryPicker() {
+    return GestureDetector(
+      onTap: () => _showCountryPicker(context),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        child: Row(
+          children: [
+            if (_selectedCountry != null) ...[
+              Text(_selectedCountry!.flag, style: const TextStyle(fontSize: 24)),
+              const SizedBox(width: 4),
+              Text('+${_selectedCountry!.dialingCode}',
+                  style: GoogleFonts.getFont('Roboto', fontSize: 18)),
+            ],
+            const Icon(Icons.arrow_drop_down),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showCountryPicker(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        String searchQuery = "";
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            final filteredCountries = _countries
+                .where((c) => c.label
+                    .toLowerCase()
+                    .contains(searchQuery.toLowerCase()))
+                .toList();
+
+            return Dialog(
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: TextField(
+                      decoration: const InputDecoration(
+                        hintText: 'Search Country',
+                        prefixIcon: Icon(Icons.search),
+                      ),
+                      onChanged: (value) {
+                        setDialogState(() {
+                          searchQuery = value;
+                        });
+                      },
+                    ),
+                  ),
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: filteredCountries.length,
+                      itemBuilder: (context, index) {
+                        final country = filteredCountries[index];
+                        return ListTile(
+                          leading: Text(country.flag,
+                              style: const TextStyle(fontSize: 24)),
+                          title: Text(country.label),
+                          trailing: Text('+${country.dialingCode}'),
+                          onTap: () {
+                            setState(() {
+                              _selectedCountry = country;
+                              _selectedCounty = null;
+                              _selectedSubCounty = null;
+                              _selectedWard = null;
+                              _onPhoneChanged();
+                            });
+                            Navigator.pop(context);
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  List<Widget> _buildGeoFields() {
+    if (_selectedCountry == null || _selectedCountry!.counties.isEmpty) {
+      return [];
+    }
+
+    return [
+      const SizedBox(height: 15.0),
+      _buildSearchableDropdown(
+        hintText: 'Select County',
+        selectedValue: _selectedCounty?.label,
+        items: _selectedCountry!.counties.map((c) => c.label).toList(),
+        onChanged: (value) {
+          setState(() {
+            _selectedCounty = _selectedCountry!.counties.firstWhere((c) => c.label == value);
+            _selectedSubCounty = null;
+            _selectedWard = null;
+            _onPhoneChanged();
+          });
+        },
+      ),
+      if (_selectedCounty != null && _selectedCounty!.subCounties.isNotEmpty) ...[
+        const SizedBox(height: 15.0),
+        _buildSearchableDropdown(
+          hintText: 'Select Sub-County',
+          selectedValue: _selectedSubCounty?.label,
+          items: _selectedCounty!.subCounties.map((sc) => sc.label).toList(),
+          onChanged: (value) {
+            setState(() {
+              _selectedSubCounty = _selectedCounty!.subCounties.firstWhere((sc) => sc.label == value);
+              _selectedWard = null;
+              _onPhoneChanged();
+            });
+          },
+        ),
+      ],
+      if (_selectedSubCounty != null && _selectedSubCounty!.wards.isNotEmpty) ...[
+        const SizedBox(height: 15.0),
+        _buildSearchableDropdown(
+          hintText: 'Select Ward',
+          selectedValue: _selectedWard,
+          items: _selectedSubCounty!.wards,
+          onChanged: (value) {
+            setState(() {
+              _selectedWard = value;
+              _onPhoneChanged();
+            });
+          },
+        ),
+      ],
+    ];
+  }
+
+  Widget _buildSearchableDropdown({
+    required String hintText,
+    required String? selectedValue,
+    required List<String> items,
+    required ValueChanged<String> onChanged,
+  }) {
+    return GestureDetector(
+      onTap: () {
+        showDialog(
+          context: context,
+          builder: (context) {
+            String searchQuery = "";
+            return StatefulBuilder(
+              builder: (context, setDialogState) {
+                final filteredItems = items
+                    .where((item) => item.toLowerCase().contains(searchQuery.toLowerCase()))
+                    .toList();
+
+                return Dialog(
+                  child: Column(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: TextField(
+                          decoration: InputDecoration(
+                            hintText: 'Search',
+                            prefixIcon: const Icon(Icons.search),
+                          ),
+                          onChanged: (value) {
+                            setDialogState(() {
+                              searchQuery = value;
+                            });
+                          },
+                        ),
+                      ),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: filteredItems.length,
+                          itemBuilder: (context, index) {
+                            final item = filteredItems[index];
+                            return ListTile(
+                              title: Text(item),
+                              onTap: () {
+                                onChanged(item);
+                                Navigator.pop(context);
+                              },
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            );
+          },
+        );
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 15.0),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(5.0),
+          border: Border.all(width: .5, color: Colors.grey),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              selectedValue ?? hintText,
+              style: GoogleFonts.getFont('Roboto',
+                  color: selectedValue != null ? Colors.black : Colors.grey,
+                  fontSize: 18),
+            ),
+            const Icon(Icons.arrow_drop_down),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/admin/delivery/add_new_delivery_screen.dart
+++ b/lib/presentation/screens/admin/delivery/add_new_delivery_screen.dart
@@ -7,22 +7,23 @@ import 'package:dukascango/domain/bloc/blocs.dart';
 import 'package:dukascango/presentation/components/components.dart';
 import 'package:dukascango/presentation/helpers/helpers.dart';
 import 'package:dukascango/presentation/screens/admin/admin_home_screen.dart';
+import 'package:dukascango/presentation/components/phone_number_field.dart';
+import 'package:dukascango/presentation/helpers/validators.dart';
 import 'package:dukascango/presentation/themes/colors_dukascango.dart';
 
 class AddNewDeliveryScreen extends StatefulWidget {
-
   @override
   _AddNewDeliveryScreenState createState() => _AddNewDeliveryScreenState();
 }
 
-
 class _AddNewDeliveryScreenState extends State<AddNewDeliveryScreen> {
-
   late TextEditingController _nameController;
   late TextEditingController _lastnameController;
-  late TextEditingController _phoneController;
   late TextEditingController _emailController;
   late TextEditingController _passwordController;
+
+  String _fullPhoneNumber = '';
+  Map<String, dynamic> _countryData = {};
 
   final _keyForm = GlobalKey<FormState>();
 
@@ -31,7 +32,6 @@ class _AddNewDeliveryScreenState extends State<AddNewDeliveryScreen> {
     super.initState();
     _nameController = TextEditingController();
     _lastnameController = TextEditingController();
-    _phoneController = TextEditingController();
     _emailController = TextEditingController();
     _passwordController = TextEditingController();
   }
@@ -41,38 +41,37 @@ class _AddNewDeliveryScreenState extends State<AddNewDeliveryScreen> {
     clearTextEditingController();
     _nameController.dispose();
     _lastnameController.dispose();
-    _phoneController.dispose();
     _emailController.dispose();
-    _passwordController.dispose();    
+    _passwordController.dispose();
     super.dispose();
   }
 
-  void clearTextEditingController(){
+  void clearTextEditingController() {
     _nameController.clear();
     _lastnameController.clear();
-    _phoneController.clear();
     _emailController.clear();
     _passwordController.clear();
   }
 
   @override
   Widget build(BuildContext context) {
-
     final userBloc = BlocProvider.of<UserBloc>(context);
 
     return BlocListener<UserBloc, UserState>(
       listener: (context, state) {
-        if( state is LoadingUserState ){
+        if (state is LoadingUserState) {
           modalLoading(context);
         }
-        if(state is SuccessUserState ){
-
+        if (state is SuccessUserState) {
           Navigator.pop(context);
-          modalSuccess(context, 'Delivery Successfully Registered', 
-            () => Navigator.pushAndRemoveUntil(context, routeDukascango(page: AdminHomeScreen()), (route) => false));
-          userBloc.add( OnClearPicturePathEvent());
+          modalSuccess(
+              context,
+              'Delivery Successfully Registered',
+              () => Navigator.pushAndRemoveUntil(context,
+                  routeDukascango(page: AdminHomeScreen()), (route) => false));
+          userBloc.add(OnClearPicturePathEvent());
         }
-        if( state is FailureUserState ){
+        if (state is FailureUserState) {
           Navigator.pop(context);
           errorMessageSnack(context, state.error);
         }
@@ -80,45 +79,51 @@ class _AddNewDeliveryScreenState extends State<AddNewDeliveryScreen> {
       child: Scaffold(
         backgroundColor: Colors.white,
         appBar: AppBar(
-            backgroundColor: Colors.white,
-            title: const TextCustom(text: 'Add New Delivery'),
-            centerTitle: true,
-            leadingWidth: 80,
-            leading: TextButton(
-              child: const TextCustom(text: 'Cancel', color: ColorsDukascango.primaryColor, fontSize: 17 ),
-              onPressed: () => Navigator.pop(context),
-            ),
-            elevation: 0,
-            actions: [
-              TextButton(
-                onPressed: () {
-                  if( _keyForm.currentState!.validate() ){
-                    userBloc.add( OnRegisterDeliveryEvent(
-                      _nameController.text, 
-                      _lastnameController.text, 
-                      _phoneController.text, 
-                      _emailController.text, 
-                      _passwordController.text, 
-                      userBloc.state.pictureProfilePath 
-                    ));
-                    
-                  }
-                }, 
-                child: const TextCustom(text: ' Save ', color: ColorsDukascango.primaryColor )
-              )
-            ],
+          backgroundColor: Colors.white,
+          title: const TextCustom(text: 'Add New Delivery'),
+          centerTitle: true,
+          leadingWidth: 80,
+          leading: TextButton(
+            child: const TextCustom(
+                text: 'Cancel',
+                color: ColorsDukascango.primaryColor,
+                fontSize: 17),
+            onPressed: () => Navigator.pop(context),
           ),
+          elevation: 0,
+          actions: [
+            TextButton(
+                onPressed: () {
+                  if (_keyForm.currentState!.validate()) {
+                    userBloc.add(OnRegisterDeliveryEvent(
+                      _nameController.text,
+                      _lastnameController.text,
+                      _fullPhoneNumber,
+                      _emailController.text,
+                      _passwordController.text,
+                      userBloc.state.pictureProfilePath,
+                      _countryData['country'],
+                      _countryData['countryCode'],
+                      _countryData['dialingCode'],
+                      _countryData['flag'],
+                      _countryData['currency'],
+                      _countryData['geo'],
+                    ));
+                  }
+                },
+                child: const TextCustom(
+                    text: ' Save ', color: ColorsDukascango.primaryColor))
+          ],
+        ),
         body: Form(
           key: _keyForm,
           child: ListView(
             physics: const BouncingScrollPhysics(),
-            padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10.0),
+            padding:
+                const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10.0),
             children: [
               const SizedBox(height: 20.0),
-              Align(
-                alignment: Alignment.center,
-                child: _PictureRegistre()
-              ),
+              Align(alignment: Alignment.center, child: _PictureRegistre()),
               const SizedBox(height: 20.0),
               const TextCustom(text: 'Name'),
               const SizedBox(height: 5.0),
@@ -133,26 +138,26 @@ class _AddNewDeliveryScreenState extends State<AddNewDeliveryScreen> {
               FormFieldDukascango(
                 controller: _lastnameController,
                 hintText: 'lastname',
-                validator: RequiredValidator(errorText: 'Lastname is required'),
+                validator:
+                    RequiredValidator(errorText: 'Lastname is required'),
               ),
               const SizedBox(height: 20.0),
-              const TextCustom(text: 'Phone'),
-              const SizedBox(height: 5.0),
-              FormFieldDukascango(
-                controller: _phoneController,
-                hintText: '---.---.---',
-                keyboardType: TextInputType.number,
-                validator: RequiredValidator(errorText: 'Lastname is required'),
+              PhoneNumberField(
+                onChanged: (fullPhoneNumber, countryData) {
+                  setState(() {
+                    _fullPhoneNumber = fullPhoneNumber;
+                    _countryData = countryData;
+                  });
+                },
               ),
               const SizedBox(height: 15.0),
               const TextCustom(text: 'Email'),
               const SizedBox(height: 5.0),
               FormFieldDukascango(
-                controller: _emailController,
-                hintText: 'email@dukascango.com',
-                keyboardType: TextInputType.emailAddress,
-                validator: validatedEmail
-              ),
+                  controller: _emailController,
+                  hintText: 'email@dukascango.com',
+                  keyboardType: TextInputType.emailAddress,
+                  validator: validatedEmail),
               const SizedBox(height: 15.0),
               const TextCustom(text: 'Password'),
               const SizedBox(height: 5.0),

--- a/lib/presentation/screens/login/register_client_screen.dart
+++ b/lib/presentation/screens/login/register_client_screen.dart
@@ -8,21 +8,22 @@ import 'package:restaurant/domain/bloc/blocs.dart';
 import 'package:restaurant/presentation/components/components.dart';
 import 'package:restaurant/presentation/helpers/helpers.dart';
 import 'package:restaurant/presentation/screens/login/login_screen.dart';
-import 'package:restaurant/presentation/themes/colors_frave.dart';
+import 'package:dukascango/presentation/components/phone_number_field.dart';
+import 'package:dukascango/presentation/themes/colors_dukascango.dart';
 
 class RegisterClientScreen extends StatefulWidget {
-
   @override
   _RegisterClientScreenState createState() => _RegisterClientScreenState();
 }
 
 class _RegisterClientScreenState extends State<RegisterClientScreen> {
-
   late TextEditingController _nameController;
   late TextEditingController _lastnameController;
-  late TextEditingController _phoneController;
   late TextEditingController _emailController;
   late TextEditingController _passwordController;
+
+  String _fullPhoneNumber = '';
+  Map<String, dynamic> _countryData = {};
 
   final _keyForm = GlobalKey<FormState>();
 
@@ -30,96 +31,97 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
   void initState() {
     _nameController = TextEditingController();
     _lastnameController = TextEditingController();
-    _phoneController = TextEditingController();
     _emailController = TextEditingController();
     _passwordController = TextEditingController();
     super.initState();
   }
-
 
   @override
   void dispose() {
     clearForm();
     _nameController.dispose();
     _lastnameController.dispose();
-    _phoneController.dispose();
     _emailController.dispose();
     _passwordController.dispose();
     super.dispose();
   }
 
-
-  void clearForm(){
+  void clearForm() {
     _nameController.clear();
     _lastnameController.clear();
-    _phoneController.clear();
     _emailController.clear();
     _passwordController.clear();
   }
 
-
   @override
   Widget build(BuildContext context) {
-
     final userBloc = BlocProvider.of<UserBloc>(context);
 
     return BlocListener<UserBloc, UserState>(
       listener: (context, state) {
-        
-        if( state is LoadingUserState ){
-
+        if (state is LoadingUserState) {
           modalLoading(context);
-
-        } else if ( state is SuccessUserState ){
-
+        } else if (state is SuccessUserState) {
           Navigator.pop(context);
-          modalSuccess(context, 'Client Registered successfully', () => Navigator.pushReplacement(context, routeFrave(page: LoginScreen())));
-        
-        } else if ( state is FailureUserState ){
-
+          modalSuccess(
+              context,
+              'Client Registered successfully',
+              () => Navigator.pushReplacement(
+                  context, routeFrave(page: LoginScreen())));
+        } else if (state is FailureUserState) {
           Navigator.pop(context);
           errorMessageSnack(context, state.error);
         }
-
       },
       child: Scaffold(
         backgroundColor: Colors.white,
         appBar: AppBar(
           leading: InkWell(
-            onTap: (){
+            onTap: () {
               Navigator.pop(context);
               clearForm();
-            } ,
+            },
             child: Container(
-              alignment: Alignment.center,
-              child: const TextCustom(text: 'Cancel', color: ColorsFrave.primaryColor, fontSize: 15)
-            ),
+                alignment: Alignment.center,
+                child: const TextCustom(
+                    text: 'Cancel',
+                    color: ColorsDukascango.primaryColor,
+                    fontSize: 15)),
           ),
           backgroundColor: Colors.white,
           elevation: 0,
           leadingWidth: 70,
-          title: const TextCustom(text: 'Create a Account',),
+          title: const TextCustom(
+            text: 'Create a Account',
+          ),
           centerTitle: true,
           actions: [
             InkWell(
               onTap: () {
-              
-                if( _keyForm.currentState!.validate()){
-
-                  userBloc.add( OnRegisterClientEvent(
+                if (_keyForm.currentState!.validate()) {
+                  userBloc.add(OnRegisterClientEvent(
                     _nameController.text,
                     _lastnameController.text,
-                    _phoneController.text,
+                    _fullPhoneNumber,
                     _emailController.text,
                     _passwordController.text,
-                     userBloc.state.pictureProfilePath
+                    userBloc.state.pictureProfilePath,
+                    _countryData['country'],
+                    _countryData['countryCode'],
+                    _countryData['dialingCode'],
+                    _countryData['flag'],
+                    _countryData['currency'],
+                    _countryData['geo'],
                   ));
                 }
               },
               child: Container(
                 margin: const EdgeInsets.only(right: 10.0),
                 alignment: Alignment.center,
-                child: const TextCustom(text: 'Save', color: ColorsFrave.primaryColor, fontSize: 15 ),
+                child: const TextCustom(
+                    text: 'Save',
+                    color: ColorsDukascango.primaryColor,
+                    fontSize: 15),
               ),
             ),
           ],
@@ -128,13 +130,11 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
           key: _keyForm,
           child: ListView(
             physics: const BouncingScrollPhysics(),
-            padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10.0),
+            padding:
+                const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10.0),
             children: [
               const SizedBox(height: 20.0),
-              Align(
-                alignment: Alignment.center,
-                child: _PictureRegistre()
-              ),
+              Align(alignment: Alignment.center, child: _PictureRegistre()),
               const SizedBox(height: 40.0),
               const TextCustom(text: 'Name'),
               const SizedBox(height: 5.0),
@@ -149,26 +149,26 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
               FormFieldFrave(
                 controller: _lastnameController,
                 hintText: 'Enter your lastname',
-                validator: RequiredValidator(errorText: 'Lastname is required'),
+                validator:
+                    RequiredValidator(errorText: 'Lastname is required'),
               ),
               const SizedBox(height: 15.0),
-              const TextCustom(text: 'Phone'),
-              const SizedBox(height: 5.0),
-              FormFieldFrave(
-                controller: _phoneController,
-                hintText: '000-000-000',
-                keyboardType: TextInputType.number,
-                validator: validatedPhoneForm,
+              PhoneNumberField(
+                onChanged: (fullPhoneNumber, countryData) {
+                  setState(() {
+                    _fullPhoneNumber = fullPhoneNumber;
+                    _countryData = countryData;
+                  });
+                },
               ),
               const SizedBox(height: 15.0),
               const TextCustom(text: 'Email'),
               const SizedBox(height: 5.0),
               FormFieldFrave(
-                controller: _emailController,
-                hintText: 'email@frave.com',
-                keyboardType: TextInputType.emailAddress,
-                validator: validatedEmail
-              ),
+                  controller: _emailController,
+                  hintText: 'email@frave.com',
+                  keyboardType: TextInputType.emailAddress,
+                  validator: validatedEmail),
               const SizedBox(height: 15.0),
               const TextCustom(text: 'Password'),
               const SizedBox(height: 5.0),

--- a/lib/presentation/screens/profile/edit_Prodile_screen.dart
+++ b/lib/presentation/screens/profile/edit_Prodile_screen.dart
@@ -4,74 +4,63 @@ import 'package:form_field_validator/form_field_validator.dart';
 import 'package:restaurant/domain/bloc/blocs.dart';
 import 'package:restaurant/presentation/components/components.dart';
 import 'package:restaurant/presentation/helpers/helpers.dart';
-import 'package:restaurant/presentation/themes/colors_frave.dart';
+import 'package:dukascango/presentation/components/phone_number_field.dart';
+import 'package:dukascango/presentation/helpers/validators.dart';
+import 'package:dukascango/presentation/themes/colors_dukascango.dart';
 
 class EditProfileScreen extends StatefulWidget {
-
   @override
   _EditProfileScreenState createState() => _EditProfileScreenState();
 }
 
-
 class _EditProfileScreenState extends State<EditProfileScreen> {
-
   late TextEditingController _nameController;
   late TextEditingController _lastNameController;
-  late TextEditingController _phoneController;
   late TextEditingController _emailController;
+
+  String _fullPhoneNumber = '';
+  Map<String, dynamic> _countryData = {};
 
   final _keyForm = GlobalKey<FormState>();
 
-  Future<void> getPersonalInformation() async {
-
-    final userBloc = BlocProvider.of<UserBloc>(context).state.user!;
-
-    _nameController = TextEditingController(text: userBloc.firstName);
-    _lastNameController = TextEditingController(text: userBloc.lastName);
-    _phoneController = TextEditingController(text: userBloc.phone);
-    _emailController = TextEditingController(text: userBloc.email );    
-  }
-
-
   @override
   void initState() {
-    super.initState();    
-    getPersonalInformation();
+    super.initState();
+    final user = BlocProvider.of<UserBloc>(context).state.user!;
+    _nameController = TextEditingController(text: user.name);
+    _lastNameController = TextEditingController(text: user.lastname);
+    _emailController = TextEditingController(text: user.email);
+    _fullPhoneNumber = user.phone ?? '';
+    _countryData = {
+      "country": user.country,
+      "countryCode": user.countryCode,
+      "dialingCode": user.dialingCode,
+      "flag": user.flag,
+      "currency": user.currency,
+      "geo": user.geo,
+    };
   }
 
   @override
-  void dispose() { 
-    _nameController.clear();
-    _lastNameController.clear();
-    _phoneController.clear();
-    _emailController.clear();
+  void dispose() {
     _nameController.dispose();
     _lastNameController.dispose();
-    _phoneController.dispose();
     _emailController.dispose();
     super.dispose();
   }
 
-
   @override
   Widget build(BuildContext context) {
-
     final userBloc = BlocProvider.of<UserBloc>(context);
 
     return BlocListener<UserBloc, UserState>(
       listener: (context, state) {
-        
-        if( state is LoadingUserState ){
-           
-           modalLoading(context);
-        
-        } else if ( state is SuccessUserState ){
-
-          Navigator.pop(context);         
+        if (state is LoadingUserState) {
+          modalLoading(context);
+        } else if (state is SuccessUserState) {
+          Navigator.pop(context);
           modalSuccess(context, 'User updated', () => Navigator.pop(context));
-        
-        } else if ( state is FailureUserState ){
-
+        } else if (state is FailureUserState) {
           Navigator.pop(context);
           errorMessageSnack(context, state.error);
         }
@@ -87,62 +76,81 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             child: Row(
               children: const [
                 SizedBox(width: 10.0),
-                Icon(Icons.arrow_back_ios_new_rounded, color: ColorsFrave.primaryColor, size: 17),
-                TextCustom(text: 'Back', fontSize: 17, color: ColorsFrave.primaryColor )
+                Icon(Icons.arrow_back_ios_new_rounded,
+                    color: ColorsDukascango.primaryColor, size: 17),
+                TextCustom(
+                    text: 'Back',
+                    fontSize: 17,
+                    color: ColorsDukascango.primaryColor)
               ],
             ),
           ),
           actions: [
             TextButton(
-              onPressed: (){
-                if( _keyForm.currentState!.validate()){
-                  userBloc.add( OnEditUserEvent( _nameController.text, _lastNameController.text, _phoneController.text ));
-                }
-              }, 
-              child: TextCustom(text: 'Update account', fontSize: 16, color: Colors.amber[900]!)
-            )
+                onPressed: () {
+                  if (_keyForm.currentState!.validate()) {
+                    userBloc.add(OnEditUserEvent(
+                      _nameController.text,
+                      _lastNameController.text,
+                      _fullPhoneNumber,
+                      _countryData['country'],
+                      _countryData['countryCode'],
+                      _countryData['dialingCode'],
+                      _countryData['flag'],
+                      _countryData['currency'],
+                      _countryData['geo'],
+                    ));
+                  }
+                },
+                child: TextCustom(
+                    text: 'Update account',
+                    fontSize: 16,
+                    color: Colors.amber[900]!))
           ],
         ),
         body: SafeArea(
           child: Form(
             key: _keyForm,
             child: ListView(
-            physics: const BouncingScrollPhysics(),
-            padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10.0),
+              physics: const BouncingScrollPhysics(),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10.0),
               children: [
-                const TextCustom(text: 'Name', color: ColorsFrave.secundaryColor),
+                const TextCustom(
+                    text: 'Name', color: ColorsDukascango.secundaryColor),
                 const SizedBox(height: 5.0),
                 FormFieldFrave(
-                  controller: _nameController,
-                  validator: RequiredValidator(errorText: 'Name is required')
-                ),
+                    controller: _nameController,
+                    validator:
+                        RequiredValidator(errorText: 'Name is required')),
                 const SizedBox(height: 20.0),
-                const TextCustom(text: 'Lastname', color: ColorsFrave.secundaryColor),
+                const TextCustom(
+                    text: 'Lastname', color: ColorsDukascango.secundaryColor),
                 const SizedBox(height: 5.0),
                 FormFieldFrave(
                   controller: _lastNameController,
                   hintText: 'lastname',
-                  validator: RequiredValidator(errorText: 'Lastname is required'),
+                  validator:
+                      RequiredValidator(errorText: 'Lastname is required'),
                 ),
                 const SizedBox(height: 20.0),
-                const TextCustom(text: 'Phone', color: ColorsFrave.secundaryColor),
-                const SizedBox(height: 5.0),
-                FormFieldFrave(
-                  controller: _phoneController,
-                  keyboardType: TextInputType.number,
-                  hintText: '000-000-000',
-                  validator: validatedPhoneForm,
+                PhoneNumberField(
+                  onChanged: (fullPhoneNumber, countryData) {
+                    setState(() {
+                      _fullPhoneNumber = fullPhoneNumber;
+                      _countryData = countryData;
+                    });
+                  },
                 ),
                 const SizedBox(height: 20.0),
-                const TextCustom(text: 'Email Address', color: ColorsFrave.secundaryColor),
+                const TextCustom(
+                    text: 'Email Address',
+                    color: ColorsDukascango.secundaryColor),
                 const SizedBox(height: 5.0),
-                FormFieldFrave(
-                  controller: _emailController,
-                  readOnly: true
-                ),
+                FormFieldFrave(controller: _emailController, readOnly: true),
                 const SizedBox(height: 20.0),
               ],
-            )
+            ),
           ),
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ flutter:
     - Assets/
     - Assets/Logo/
     - Assets/svg/
+    - assets/json/
 
 
   # To add custom fonts to your application, add a fonts section here,


### PR DESCRIPTION
I've introduced a new custom phone number input widget and integrated it into your user registration, delivery person registration, and profile editing screens.

Key changes:

- **New Widget (`PhoneNumberField`):** A stateful widget that provides a comprehensive phone number input experience. It includes:
  - A searchable country selector that displays the country flag and dialing code.
  - A text input for the local phone number, styled to match your app's existing form fields.
  - Cascading, searchable dropdowns for County, Sub-County, and Ward, which appear conditionally for countries with geographical data (e.g., Kenya).
  - Logic to only show geo-fields after a phone number has been entered.

- **Data Scaffolding:**
  - I added a `country_data.json` file containing a cleaned and merged list of countries with their metadata.
  - The JSON includes detailed geographical data for Kenya.
  - I updated `pubspec.yaml` to include the new asset.

- **Model and State Management Updates:**
  - I extended the `User` model to include new fields: `country`, `countryCode`, `dialingCode`, `flag`, `currency`, and `geo`.
  - I updated the `UserBloc` to handle the new data in the `OnRegisterClientEvent`, `OnRegisterDeliveryEvent`, and `OnEditUserEvent`.
  - I implemented the registration logic in the BLoC, which was previously a TODO.

- **Bug Fixes:**
  - I added a `copyWith` method to the `User` model, which was missing and caused an error in the profile editing screen.
  - I fixed incorrect field access in `edit_Prodile_screen.dart` (`firstName` -> `name`, `lastName` -> `lastname`).

- **Integration:**
  - I integrated the new `PhoneNumberField` into:
    - `register_client_screen.dart`
    - `add_new_delivery_screen.dart`
    - `edit_Prodile_screen.dart`